### PR TITLE
Feature: Save Parameters BT PT and RT

### DIFF
--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -519,7 +519,8 @@ class AlgoBullsConnection:
                     break
 
         # save BT/PT/RT parameters
-        self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
+        self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual,
+                             'vendor_details': broking_details}
 
         # log the saved parameters
         _print_params = self.saved_params

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -403,7 +403,7 @@ Executing strategy \'{_['strategy_code']}\' in '{trading_type.name}' with the fo
 Start Timestamp: {_['start_timestamp_map'][trading_type]}
 End Timestamp: {_['end_timestamp_map'][trading_type]}
 Parameters: {pprint.pformat(_['strategy_parameters'])}
-Candle: {_['candle_interval'].name}
+Candle: {_['candle_interval'].value}
 Instrument(s): {pprint.pformat(_['instruments'])}
 Mode: {_['strategy_mode'].name}
 Lots: {_['lots']}

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -547,7 +547,7 @@ class AlgoBullsConnection:
 
         # save BT/PT/RT parameters
         self.saved_parameters = {
-            'strategy': strategy_code,
+            'strategy_code': strategy_code,
             'start_timestamp_map': start_timestamp_map,
             'end_timestamp_map': end_timestamp_map,
             'strategy_parameters': strategy_parameters,

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -422,6 +422,7 @@ class AlgoBullsConnection:
             location of the instruments
         """
         # check if values received by new parameter names, else extract from old parameter names, else extract from saved parameters
+
         saved_params = self.saved_params
         _start = saved_params.get('start')
         _end = saved_params.get('end')
@@ -518,8 +519,8 @@ class AlgoBullsConnection:
             _end[trading_type.name] = end
 
         # save BT/PT/RT parameters
-        self.saved_params[strategy] = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
-
+        self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
+        print(self.saved_params)
         # delete previous trades
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING] and delete_previous_trades:
             self.delete_previous_trades(strategy)

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -425,8 +425,8 @@ class AlgoBullsConnection:
 
         # check if values received by new parameter names, else extract from old parameter names, else extract from saved parameters
         saved_params = self.saved_parameters
-        start_timestamp_map = saved_params.get('start')
-        end_timestamp_map = saved_params.get('end')
+        start_timestamp_map = saved_params.get('start_timestamp_map')
+        end_timestamp_map = saved_params.get('end_timestamp_map')
         strategy = strategy or kwargs.get('strategy_code') or saved_params.get('strategy')
         start_timestamp = start_timestamp or kwargs.get('start_timestamp') or start_timestamp_map.get(trading_type)
         end_timestamp = end_timestamp or kwargs.get('end_timestamp') or end_timestamp_map.get(trading_type)
@@ -519,7 +519,7 @@ class AlgoBullsConnection:
                     break
 
         # save BT/PT/RT parameters
-        self.saved_parameters = {'strategy': strategy, 'start': start_timestamp_map, 'end': end_timestamp_map, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots,
+        self.saved_parameters = {'strategy': strategy, 'start_timestamp_map': start_timestamp_map, 'end_timestamp_map': end_timestamp_map, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots,
                                  'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
 
         # log the saved parameters
@@ -529,7 +529,7 @@ class AlgoBullsConnection:
         pprint.pprint(_print_params)
 
         # delete previous trades
-        if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING] and delete_previous_trades:
+        if delete_previous_trades and trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING]:
             self.delete_previous_trades(strategy)
 
         # Setup config for starting the job

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -396,26 +396,31 @@ class AlgoBullsConnection:
         return order_report
 
     def print_strategy_config(self, trading_type):
+        from tabulate import tabulate
         _ = self.saved_parameters
-        _msg = f"""
-Executing strategy \'{_['strategy_code']}\' in '{trading_type.name}' with the following parameters:
 
-Start Timestamp: {_['start_timestamp_map'][trading_type]}
-End Timestamp: {_['end_timestamp_map'][trading_type]}
-Parameters: {pprint.pformat(_['strategy_parameters'])}
-Candle: {_['candle_interval'].value}
-Instrument(s): {pprint.pformat(_['instruments'])}
-Mode: {_['strategy_mode'].name}
-Lots: {_['lots']}
-"""
+        tabulated_data = [
+            ['Strategy Code', _['strategy_code']],
+            ['Trading Type', trading_type],
+            ['Instrument(s)', pprint.pformat(_['instruments'])],
+            ['Quantity/Lots', _['lots']],
+            ['Start Timestamp', _['start_timestamp_map'][trading_type]],
+            ['End Timestamp', _['end_timestamp_map'][trading_type]],
+            ['Parameters', pprint.pformat(_['strategy_parameters'])],
+            ['Candle', _['candle_interval'].value],
+            ['Mode', _['strategy_mode'].name],
+        ]
 
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING]:
-            _msg += f"Initial Funds (Virtual): {_['initial_funds_virtual']}"
+            tabulated_data.append(['Initial Funds (Virtual)', _['initial_funds_virtual']])
         elif trading_type in [TradingType.REALTRADING]:
-            _msg += f"\nBroker Details: {_['vendor_details']}"      # Note, key is still 'vendor_details' even for broking purpose
+            tabulated_data.insert(0, ["Broker Name", _['vendor_details']['brokerName']])  # Note, key is still 'vendor_details' even for broking purpose
 
         if _.get('vendor_details') is not None:
-            _msg += f"\nVendor Details: {_['vendor_details']}"
+            tabulated_data.insert(0, ["Vendor Name", _['vendor_details']['brokerName']])
+
+        _msg = tabulate(tabulated_data, headers=['Config', 'Value'], tablefmt="fancy_grid")
+
         print(_msg)
 
     def start_job(self, strategy_code=None, start_timestamp=None, end_timestamp=None, instruments=None, lots=None, strategy_parameters=None, candle_interval=None, strategy_mode=None, initial_funds_virtual=None, delete_previous_trades=True,

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -37,8 +37,6 @@ class AlgoBullsConnection:
         self.papertrade_pnl_data = None
         self.realtrade_pnl_data = None
 
-
-
     @staticmethod
     def get_authorization_url():
         """
@@ -365,7 +363,7 @@ class AlgoBullsConnection:
 
         # get pnl data and cleanup as per quantstats format
         _returns_df = pnl_df[['entry_timestamp', 'pnl_absolute']]
-        _returns_df['entry_timestamp'] = _returns_df['entry_timestamp'].dt.tz_localize(None)            # Note: Quantstats has a bug. It doesn't accept the df index, which is set below, with timezone. Hence, we have to drop the timezone info
+        _returns_df['entry_timestamp'] = _returns_df['entry_timestamp'].dt.tz_localize(None)  # Note: Quantstats has a bug. It doesn't accept the df index, which is set below, with timezone. Hence, we have to drop the timezone info
         _returns_df = _returns_df.set_index('entry_timestamp')
         _returns_df["total_funds"] = _returns_df.pnl_absolute.cumsum() + initial_funds
         _returns_df = _returns_df.dropna()

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -27,7 +27,7 @@ class AlgoBullsConnection:
         Init method that is used while creating an object of this class
         """
         self.api = AlgoBullsAPI(self)
-        self.saved_parameters = {'start': {}, 'end': {}}
+        self.saved_parameters = {'start_timestamp_map': {}, 'end_timestamp_map': {}}
         self.strategy_locale_map = {
             TradingType.BACKTESTING: {},
             TradingType.PAPERTRADING: {},

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -519,8 +519,8 @@ class AlgoBullsConnection:
                     break
 
         # save BT/PT/RT parameters
-        self.saved_parameters = {'strategy': strategy, 'start': start_timestamp_map, 'end': end_timestamp_map, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual,
-                             'vendor_details': broking_details}
+        self.saved_parameters = {'strategy': strategy, 'start': start_timestamp_map, 'end': end_timestamp_map, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots,
+                                 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
 
         # log the saved parameters
         _print_params = self.saved_parameters
@@ -871,7 +871,8 @@ class AlgoBullsConnection:
         """
 
         # start realtrading job
-        response = self.start_job(strategy=strategy, start_timestamp=start, end_timestamp=end, instruments=instruments, lots=lots, parameters=parameters, candle=candle, mode=mode, trading_type=TradingType.REALTRADING, broking_details=broking_details, **kwargs)
+        response = self.start_job(strategy=strategy, start_timestamp=start, end_timestamp=end, instruments=instruments, lots=lots, parameters=parameters, candle=candle, mode=mode, trading_type=TradingType.REALTRADING, broking_details=broking_details,
+                                  **kwargs)
 
         # Update previously saved pnl data and exchange location
         self.realtrade_pnl_data = None

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -171,10 +171,11 @@ class AlgoBullsConnection:
         """
         strategy_name = None
         try:
+            # TODO: Currently fetching strategy name over API everytime. Will be optimized in future to avoid repeated API calls.
             all_strategies_df = self.get_all_strategies()
-            strategy_name = all_strategies_df.loc[all_strategies_df['strategyCode'] == 'c903da8c49a245e685911fa20f3d9314']['strategyName'][0]
-        except Exception as e:
-            print(f'Error while fetching strategy name of strategy code {strategy_code}. Error: {e}')
+            strategy_name = all_strategies_df.loc[all_strategies_df['strategyCode'] == strategy_code]['strategyName'][0]
+        except Exception as ex:
+            print(f'Error while fetching strategy name of strategy code {strategy_code}. Error: {ex}')
         return strategy_name
 
     def get_strategy_details(self, strategy_code):
@@ -416,12 +417,11 @@ class AlgoBullsConnection:
 
     def print_strategy_config(self, trading_type):
         _ = self.saved_parameters
-
         strategy_name = self.get_strategy_name(_['strategy_code'])
 
-        tabulated_data = [
-            # ['Strategy Code', _['strategy_code']],    # not required as of now
+        data = [
             ['Strategy Name', strategy_name],
+            # ['Strategy Code', _['strategy_code']],    # not required as of now
             ['Trading Type', trading_type.name],
             ['Instrument(s)', pprint.pformat(_['instruments'])],
             ['Quantity/Lots', _['lots']],
@@ -433,14 +433,14 @@ class AlgoBullsConnection:
         ]
 
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING]:
-            tabulated_data.append(['Initial Funds (Virtual)', _['initial_funds_virtual']])
+            data.append(['Initial Funds (Virtual)', _['initial_funds_virtual']])
         elif trading_type in [TradingType.REALTRADING]:
-            tabulated_data.insert(0, ["Broker Name", _['vendor_details']['brokerName']])  # Note, key is still 'vendor_details' even for broking purpose
+            data.insert(0, ["Broker Name", _['vendor_details']['brokerName']])  # Note, key is still 'vendor_details' even for broking purpose
 
         if _.get('vendor_details') is not None:
-            tabulated_data.insert(0, ["Vendor Name", _['vendor_details']['brokerName']])
+            data.insert(0, ["Vendor Name", _['vendor_details']['brokerName']])
 
-        _msg = tabulate(tabulated_data, headers=['Config', 'Value'], tablefmt="fancy_grid")
+        _msg = tabulate(data, headers=['Config', 'Value'], tablefmt="fancy_grid")
         print(f"\nStarting the strategy '{strategy_name}' in {trading_type.name} mode...\n{_msg}\n")
 
     def start_job(self, strategy_code=None, start_timestamp=None, end_timestamp=None, instruments=None, lots=None, strategy_parameters=None, candle_interval=None, strategy_mode=None, initial_funds_virtual=None, delete_previous_trades=True,

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -520,7 +520,16 @@ class AlgoBullsConnection:
 
         # save BT/PT/RT parameters
         self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
-        print(self.saved_params)
+
+        # log the saved parameters
+        _print_params = self.saved_params
+        del _print_params['start']
+        del _print_params['end']
+        print(f'start: {_start[trading_type.name]}')
+        print(f'end: {_end[trading_type.name]}')
+        print("\n".join("{}:\t{}".format(k, v) for k, v in _print_params.items()))
+        print('-'*20, '\n')
+
         # delete previous trades
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING] and delete_previous_trades:
             self.delete_previous_trades(strategy)

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -401,7 +401,7 @@ class AlgoBullsConnection:
 
         tabulated_data = [
             ['Strategy Code', _['strategy_code']],
-            ['Trading Type', trading_type],
+            ['Trading Type', trading_type.name],
             ['Instrument(s)', pprint.pformat(_['instruments'])],
             ['Quantity/Lots', _['lots']],
             ['Start Timestamp', _['start_timestamp_map'][trading_type]],
@@ -420,8 +420,7 @@ class AlgoBullsConnection:
             tabulated_data.insert(0, ["Vendor Name", _['vendor_details']['brokerName']])
 
         _msg = tabulate(tabulated_data, headers=['Config', 'Value'], tablefmt="fancy_grid")
-
-        print(_msg)
+        print(f"\nStarting the strategy '{_['strategy_code']}' in {trading_type.name} mode...\n_msg\n")
 
     def start_job(self, strategy_code=None, start_timestamp=None, end_timestamp=None, instruments=None, lots=None, strategy_parameters=None, candle_interval=None, strategy_mode=None, initial_funds_virtual=None, delete_previous_trades=True,
                   trading_type=None, broking_details=None, **kwargs):
@@ -513,13 +512,13 @@ class AlgoBullsConnection:
             assert 'credentialParameters' in broking_details, f'Argument "broking_details" should be a dict with "credentialParameters" key'
 
         if trading_type is not TradingType.BACKTESTING:
+            start_timestamp = dt.combine(dt.now().astimezone(start_timestamp.tzinfo).date(), start_timestamp.time(), tzinfo=start_timestamp.tzinfo)
+            end_timestamp = dt.combine(dt.now().astimezone(end_timestamp.tzinfo).date(), end_timestamp.time(), tzinfo=end_timestamp.tzinfo)
+
             start_timestamp_map[TradingType.REALTRADING] = start_timestamp
             start_timestamp_map[TradingType.PAPERTRADING] = start_timestamp
             end_timestamp_map[TradingType.REALTRADING] = end_timestamp
             end_timestamp_map[TradingType.PAPERTRADING] = end_timestamp
-
-            start_timestamp = dt.combine(dt.now().astimezone(start_timestamp.tzinfo).date(), start_timestamp.time(), tzinfo=start_timestamp.tzinfo)
-            end_timestamp = dt.combine(dt.now().astimezone(end_timestamp.tzinfo).date(), end_timestamp.time(), tzinfo=end_timestamp.tzinfo)
 
         else:
             start_timestamp_map[TradingType.BACKTESTING] = start_timestamp

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -519,7 +519,7 @@ class AlgoBullsConnection:
             _end[trading_type.name] = end
 
         # save BT/PT/RT parameters
-        self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
+        self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details}
 
         # log the saved parameters
         _print_params = self.saved_params

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -710,6 +710,7 @@ class AlgoBullsConnection:
         Returns:
             papertrade job submission status
         """
+
         saved_params = self.saved_params.get(strategy) or {}
 
         # start papertrading job

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -27,7 +27,7 @@ class AlgoBullsConnection:
         Init method that is used while creating an object of this class
         """
         self.api = AlgoBullsAPI(self)
-        self.saved_params = {'start': {}, 'end': {}}
+        self.saved_parameters = {'start': {}, 'end': {}}
         self.strategy_locale_map = {
             TradingType.BACKTESTING: {},
             TradingType.PAPERTRADING: {},
@@ -424,7 +424,7 @@ class AlgoBullsConnection:
         """
         # check if values received by new parameter names, else extract from old parameter names, else extract from saved parameters
 
-        saved_params = self.saved_params
+        saved_params = self.saved_parameters
         _start = saved_params.get('start')
         _end = saved_params.get('end')
         strategy = strategy or kwargs.get('strategy_code') or saved_params.get('strategy')
@@ -519,11 +519,11 @@ class AlgoBullsConnection:
                     break
 
         # save BT/PT/RT parameters
-        self.saved_params = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual,
+        self.saved_parameters = {'strategy': strategy, 'start': _start, 'end': _end, 'parameters': parameters, 'candle': candle.value, 'instruments': instruments, 'mode': mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual,
                              'vendor_details': broking_details}
 
         # log the saved parameters
-        _print_params = self.saved_params
+        _print_params = self.saved_parameters
         _print_params['start'] = _start[trading_type]
         _print_params['end'] = _end[trading_type]
         pprint.pprint(_print_params)

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -403,9 +403,9 @@ Executing strategy \'{_['strategy_code']}\' in '{trading_type.name}' with the fo
 Start Timestamp: {_['start_timestamp_map'][trading_type]}
 End Timestamp: {_['end_timestamp_map'][trading_type]}
 Parameters: {pprint.pformat(_['strategy_parameters'])}
-Candle: {_['candle_interval']}
+Candle: {_['candle_interval'].name}
 Instrument(s): {pprint.pformat(_['instruments'])}
-Mode: {_['strategy_mode']}
+Mode: {_['strategy_mode'].name}
 Lots: {_['lots']}
 """
 

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -407,7 +407,7 @@ Candle: {_['candle_interval']}
 Instrument(s): {pprint.pformat(_['instruments'])}
 Mode: {_['strategy_mode']}
 Lots: {_['lots']}
-        """
+"""
 
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING]:
             _msg += f"Initial Funds (Virtual): {_['initial_funds_virtual']}"
@@ -455,13 +455,13 @@ Lots: {_['lots']}
         saved_params = self.saved_parameters
         start_timestamp_map = saved_params.get('start_timestamp_map')
         end_timestamp_map = saved_params.get('end_timestamp_map')
-        strategy_code = strategy_code or kwargs.get('strategy_code') or saved_params.get('strategy')
+        strategy_code = strategy_code or kwargs.get('strategy_code') or saved_params.get('strategy_code')
         start_timestamp = start_timestamp or kwargs.get('start_timestamp') or start_timestamp_map.get(trading_type)
         end_timestamp = end_timestamp or kwargs.get('end_timestamp') or end_timestamp_map.get(trading_type)
-        strategy_parameters = strategy_parameters or kwargs.get('strategy_parameters') or saved_params.get('parameters')
-        candle_interval = candle_interval or kwargs.get('candle_interval') or saved_params.get('candle')
+        strategy_parameters = strategy_parameters or kwargs.get('strategy_parameters') or saved_params.get('strategy_parameters')
+        candle_interval = candle_interval or kwargs.get('candle_interval') or saved_params.get('candle_interval')
         instruments = instruments or kwargs.get('instrument') or saved_params.get('instruments')
-        strategy_mode = strategy_mode or kwargs.get('strategy_mode') or saved_params.get('mode') or StrategyMode.INTRADAY
+        strategy_mode = strategy_mode or kwargs.get('strategy_mode') or saved_params.get('strategy_mode') or StrategyMode.INTRADAY
         lots = lots or saved_params.get('lots')
         initial_funds_virtual = initial_funds_virtual or saved_params.get('initial_funds_virtual') or 1e9
         broking_details = broking_details or saved_params.get('vendor_details')

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -398,19 +398,19 @@ class AlgoBullsConnection:
     def print_strategy_config(self, trading_type):
         _ = self.saved_parameters
         _msg = f"""
-            Executing strategy \'{_['strategy_code']}\' in '{trading_type.name}' with the following parameters:
-            
-            Start Timestamp: {_['start_timestamp_map'][trading_type]}
-            End Timestamp: {_['end_timestamp_map'][trading_type]}
-            Parameters: {pprint.pformat(_['strategy_parameters'])}
-            Candle: {_['candle_interval']}
-            Instrument(s): {pprint.pformat(_['instruments'])}
-            Mode: {_['strategy_mode']}
-            Lots: {_['lots']}
+Executing strategy \'{_['strategy_code']}\' in '{trading_type.name}' with the following parameters:
+
+Start Timestamp: {_['start_timestamp_map'][trading_type]}
+End Timestamp: {_['end_timestamp_map'][trading_type]}
+Parameters: {pprint.pformat(_['strategy_parameters'])}
+Candle: {_['candle_interval']}
+Instrument(s): {pprint.pformat(_['instruments'])}
+Mode: {_['strategy_mode']}
+Lots: {_['lots']}
         """
 
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING]:
-            _msg += f"\nInitial Funds (Virtual): {_['initial_funds_virtual']}"
+            _msg += f"Initial Funds (Virtual): {_['initial_funds_virtual']}"
         elif trading_type in [TradingType.REALTRADING]:
             _msg += f"\nBroker Details: {_['vendor_details']}"      # Note, key is still 'vendor_details' even for broking purpose
 

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -37,8 +37,6 @@ class AlgoBullsConnection:
         self.papertrade_pnl_data = None
         self.realtrade_pnl_data = None
 
-
-
     @staticmethod
     def get_authorization_url():
         """
@@ -296,7 +294,7 @@ class AlgoBullsConnection:
         else:
             print('Report not available yet. Please retry in sometime')
 
-    def get_pnl_report_table(self, strategy_code, trading_type, location):
+    def get_pnl_report_table(self, strategy_code, trading_type, location, broker_commission_percentage=0, broker_commission_price=None):
         """
             Fetch BT/PT/RT Profit & Loss details
 
@@ -304,6 +302,8 @@ class AlgoBullsConnection:
                 strategy_code: strategy code
                 trading_type: type of trades : Backtesting, Papertrading, Realtrading
                 location: Location of the exchange
+                broker_commission_percentage: Percentage of broker commission per trade
+                broker_commission_price: Broker fee per trade
 
             Returns:
                 Report details
@@ -341,9 +341,16 @@ class AlgoBullsConnection:
             _df['exit_transaction_type'] = _df['exit_transaction_type'].apply(lambda _: 'BUY' if _ else 'SELL')
             _df["pnl_cumulative_absolute"] = _df["pnl_absolute"].cumsum(axis=0, skipna=True)
 
+            # add brokerage
+            _df['brokerage'] = ((_df['entry_price'] * _df['entry_quantity']) + (_df['exit_price'] * _df['exit_quantity'])) * (broker_commission_percentage / 100)
+            if broker_commission_price is not None:
+                _df["brokerage"].loc[_df["brokerage"] > broker_commission_price] = broker_commission_price
+            _df['net_pnl'] = _df['pnl_absolute'] - _df['brokerage']
+
         else:
             # No data available, send back an empty dataframe
             _df = pd.DataFrame(columns=list(column_rename_map.values()))
+            _df['net_pnl'] = None
 
         return _df
 
@@ -364,7 +371,7 @@ class AlgoBullsConnection:
         order_report = None
 
         # get pnl data and cleanup as per quantstats format
-        _returns_df = pnl_df[['entry_timestamp', 'pnl_absolute']]
+        _returns_df = pnl_df[['entry_timestamp', 'net_pnl']]
         _returns_df['entry_timestamp'] = _returns_df['entry_timestamp'].dt.tz_localize(None)            # Note: Quantstats has a bug. It doesn't accept the df index, which is set below, with timezone. Hence, we have to drop the timezone info
         _returns_df = _returns_df.set_index('entry_timestamp')
         _returns_df["total_funds"] = _returns_df.pnl_absolute.cumsum() + initial_funds
@@ -621,7 +628,7 @@ class AlgoBullsConnection:
 
         return self.get_logs(strategy_code, trading_type=TradingType.BACKTESTING)
 
-    def get_backtesting_report_pnl_table(self, strategy_code, location=None, show_all_rows=False, force_fetch=False):
+    def get_backtesting_report_pnl_table(self, strategy_code, location=None, show_all_rows=False, force_fetch=False, broker_commission_percentage=0, broker_commission_price=None):
         """
         Fetch Back Testing Profit & Loss details
 
@@ -630,13 +637,15 @@ class AlgoBullsConnection:
             location: Location of Exchange
             show_all_rows: True or False
             force_fetch: Forcefully fetch PnL data
+            broker_commission_percentage: Percentage of broker commission per trade
+            broker_commission_price: Broker fee per trade
 
         Returns:
             Report details
         """
 
         if self.backtesting_pnl_data is None or location is not None or force_fetch:
-            self.backtesting_pnl_data = self.get_pnl_report_table(strategy_code, TradingType.BACKTESTING, location)
+            self.backtesting_pnl_data = self.get_pnl_report_table(strategy_code, TradingType.BACKTESTING, location, broker_commission_percentage, broker_commission_price)
 
         return self.backtesting_pnl_data
 
@@ -767,7 +776,7 @@ class AlgoBullsConnection:
 
         return self.get_logs(strategy_code=strategy_code, trading_type=TradingType.PAPERTRADING)
 
-    def get_papertrading_report_pnl_table(self, strategy_code, location=None, show_all_rows=False, force_fetch=False):
+    def get_papertrading_report_pnl_table(self, strategy_code, location=None, show_all_rows=False, force_fetch=False, broker_commission_percentage=0, broker_commission_price=None):
         """
         Fetch Paper Trading Profit & Loss details
 
@@ -776,13 +785,15 @@ class AlgoBullsConnection:
             location: Location of the exchange
             show_all_rows: True or False
             force_fetch: Forcefully fetch PnL data
+            broker_commission_percentage: Percentage of broker commission per trade
+            broker_commission_price: Broker fee per trade
 
         Returns:
             Report details
         """
 
         if self.papertrade_pnl_data is None or location is not None or force_fetch:
-            self.papertrade_pnl_data = self.get_pnl_report_table(strategy_code, TradingType.PAPERTRADING, location)
+            self.papertrade_pnl_data = self.get_pnl_report_table(strategy_code, TradingType.PAPERTRADING, location, broker_commission_percentage, broker_commission_price)
 
         return self.papertrade_pnl_data
 
@@ -912,7 +923,7 @@ class AlgoBullsConnection:
 
         return self.get_logs(strategy_code=strategy_code, trading_type=TradingType.REALTRADING)
 
-    def get_realtrading_report_pnl_table(self, strategy_code, location=None, show_all_rows=False, force_fetch=False):
+    def get_realtrading_report_pnl_table(self, strategy_code, location=None, show_all_rows=False, force_fetch=False, broker_commission_percentage=0, broker_commission_price=None):
         """
         Fetch Real Trading Profit & Loss details
 
@@ -921,13 +932,15 @@ class AlgoBullsConnection:
             location: Location of the Exchange
             show_all_rows: True or False
             force_fetch: Forcefully fetch PnL data
+            broker_commission_percentage: Percentage of broker commission per trade
+            broker_commission_price: Broker fee per trade
 
         Returns:
             Report details
         """
 
         if self.realtrade_pnl_data is None or location is not None or force_fetch:
-            self.realtrade_pnl_data = self.get_pnl_report_table(strategy_code, TradingType.REALTRADING, location)
+            self.realtrade_pnl_data = self.get_pnl_report_table(strategy_code, TradingType.REALTRADING, location, broker_commission_percentage, broker_commission_price)
 
         return self.realtrade_pnl_data
 

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -547,8 +547,16 @@ class AlgoBullsConnection:
 
         # save BT/PT/RT parameters
         self.saved_parameters = {
-            'strategy': strategy_code, 'start_timestamp_map': start_timestamp_map, 'end_timestamp_map': end_timestamp_map, 'strategy_parameters': strategy_parameters, 'candle_interval': candle_interval, 'instruments': instruments,
-            'strategy_mode': strategy_mode, 'lots': lots, 'initial_funds_virtual': initial_funds_virtual, 'vendor_details': broking_details
+            'strategy': strategy_code,
+            'start_timestamp_map': start_timestamp_map,
+            'end_timestamp_map': end_timestamp_map,
+            'strategy_parameters': strategy_parameters,
+            'candle_interval': candle_interval,
+            'instruments': instruments,
+            'strategy_mode': strategy_mode,
+            'lots': lots,
+            'initial_funds_virtual': initial_funds_virtual,
+            'vendor_details': broking_details   # Note: key name is saved as vendor_details for logging purpose
         }
 
         self.print_strategy_config(trading_type)

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -416,6 +416,7 @@ class AlgoBullsConnection:
 
         if _.get('vendor_details') is not None:
             _msg += f"\nVendor Details: {_['vendor_details']}"
+        print(_msg)
 
     def start_job(self, strategy_code=None, start_timestamp=None, end_timestamp=None, instruments=None, lots=None, strategy_parameters=None, candle_interval=None, strategy_mode=None, initial_funds_virtual=None, delete_previous_trades=True,
                   trading_type=None, broking_details=None, **kwargs):

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -2,6 +2,7 @@
 Module for AlgoBulls connection
 """
 import inspect
+import pprint
 import time
 from collections import OrderedDict
 from datetime import datetime as dt
@@ -523,12 +524,9 @@ class AlgoBullsConnection:
 
         # log the saved parameters
         _print_params = self.saved_params
-        del _print_params['start']
-        del _print_params['end']
-        print(f'start: {_start[trading_type.name]}')
-        print(f'end: {_end[trading_type.name]}')
-        print("\n".join("{}:\t{}".format(k, v) for k, v in _print_params.items()))
-        print('-'*20, '\n')
+        _print_params['start'] = _start[trading_type]
+        _print_params['end'] = _end[trading_type]
+        pprint.pprint(_print_params)
 
         # delete previous trades
         if trading_type in [TradingType.BACKTESTING, TradingType.PAPERTRADING] and delete_previous_trades:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests>=2.24.0
 pandas>=0.25.3,<2.0.0
 quantstats==0.0.59
+
+setuptools~=65.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.24.0
 pandas>=0.25.3,<2.0.0
 quantstats==0.0.59
-
-setuptools~=65.5.1
+tabulate==0.9.0


### PR DESCRIPTION
- added saved_params to connection object to save extra params
- only params that are needed to pass for 2nd run : strategy, start, end, delete_previous_trades
- #28 issue-enhancement is added here
- this feature is applied for RT as well
- `strategy_code` or `strategy` is now a common saved parameter
- `start` and `end` time need not be given if running RT after a succesful PT or PT after a succesful RT