### PR TITLE
Bug: strategy parameters when passed as None or Empty dictionary, raised an error in "start_job" methods

### DIFF
--- a/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
+++ b/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
@@ -84,6 +84,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6d12741c",
+   "metadata": {},
+   "source": [
+    "## Import Strategy from pyaglostrategypool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e06b89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
+    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "6cbd40df",
@@ -133,25 +152,6 @@
    "metadata": {},
    "source": [
     "# Strategy Testing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d12741c",
-   "metadata": {},
-   "source": [
-    "## Import Strategy from pyaglostrategypool"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15e06b89",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
-    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
    ]
   },
   {
@@ -32471,7 +32471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -602,6 +602,8 @@ class AlgoBullsConnection:
             candle_interval = CandleInterval[_]
         if isinstance(instruments, str):
             instruments = [instruments]
+        if strategy_parameters == {} or strategy_parameters is None:
+            strategy_parameters = dict()
 
         # Sanity checks - Validate config parameters
         assert isinstance(strategy_code, str), f'Argument "strategy" should be a valid string'


### PR DESCRIPTION
- Strategy Parameters when passed as empty would raise an error.
- To pass an empty dictionary or None in parameters this feature was needed.
- If a None value or Empty Dictionary is passed, it is initialized as a dictionary in the `start_job` method.
- This PR is closes in PR #65 
