### PR TITLE
Bug: initial funds although saved, was no retrieved during statistics

### DIFF
--- a/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
+++ b/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
@@ -84,6 +84,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6d12741c",
+   "metadata": {},
+   "source": [
+    "## Import Strategy from pyaglostrategypool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e06b89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
+    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "6cbd40df",
@@ -133,25 +152,6 @@
    "metadata": {},
    "source": [
     "# Strategy Testing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d12741c",
-   "metadata": {},
-   "source": [
-    "## Import Strategy from pyaglostrategypool"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15e06b89",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
-    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
    ]
   },
   {
@@ -32471,7 +32471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -804,7 +804,7 @@ class AlgoBullsConnection:
 
         return self.backtesting_pnl_data
 
-    def get_backtesting_report_statistics(self, strategy_code, initial_funds=1e9, mode='quantstats', report='metrics', html_dump=False):
+    def get_backtesting_report_statistics(self, strategy_code, initial_funds=None, mode='quantstats', report='metrics', html_dump=False):
         """
         Fetch Back Testing report statistics
 
@@ -825,6 +825,9 @@ class AlgoBullsConnection:
             self.get_backtesting_report_pnl_table(strategy_code)
         else:
             print('Generating Statistics for already fetched P&L data...')
+
+        if initial_funds is None:
+            initial_funds = self.saved_parameters.get("initial_funds_virtual") or 1e9
 
         order_report = self.get_report_statistics(strategy_code, initial_funds, report, html_dump, self.backtesting_pnl_data)
 
@@ -950,7 +953,7 @@ class AlgoBullsConnection:
 
         return self.papertrade_pnl_data
 
-    def get_papertrading_report_statistics(self, strategy_code, initial_funds=1e9, mode='quantstats', report='metrics', html_dump=False):
+    def get_papertrading_report_statistics(self, strategy_code, initial_funds=None, mode='quantstats', report='metrics', html_dump=False):
         """
         Fetch Paper Trading report statistics
 
@@ -971,6 +974,9 @@ class AlgoBullsConnection:
             self.get_papertrading_report_pnl_table(strategy_code)
         else:
             print('Generating Statistics for already fetched P&L data...')
+
+        if initial_funds is None:
+            initial_funds = self.saved_parameters.get("initial_funds_virtual") or 1e9
 
         order_report = self.get_report_statistics(strategy_code, initial_funds, report, html_dump, self.papertrade_pnl_data)
 
@@ -1099,7 +1105,7 @@ class AlgoBullsConnection:
 
         return self.realtrade_pnl_data
 
-    def get_realtrading_report_statistics(self, strategy_code, initial_funds=1e9, mode='quantstats', report='metrics', html_dump=False):
+    def get_realtrading_report_statistics(self, strategy_code, initial_funds=None, mode='quantstats', report='metrics', html_dump=False):
         """
         Fetch Real Trading report statistics
 
@@ -1120,6 +1126,9 @@ class AlgoBullsConnection:
             self.get_realtrading_report_pnl_table(strategy_code)
         else:
             print('Generating Statistics for already fetched P&L data...')
+
+        if initial_funds is None:
+            initial_funds = self.saved_parameters.get("initial_funds_virtual") or 1e9
 
         order_report = self.get_report_statistics(strategy_code, initial_funds, report, html_dump, self.realtrade_pnl_data)
 


### PR DESCRIPTION
- Initial Funds were already getting saved in `saved_parameters` dictionary
- Now these funds are fetched when calculating statistics.
- If the user specifically passes the value to `initial_funds` parameter in `get_report_statistics` method, then we will take this value into consideration when generating statistics.
- If neither options is available, i.e no `saved_parameters` dictionary and nor user specified value for `initial_funds`, then we give the value as 1e9.
- This PR is closes in PR #65 
