### PR TITLE
Feature: External file can be provided for statistics

### DIFF
--- a/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
+++ b/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
@@ -84,6 +84,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6d12741c",
+   "metadata": {},
+   "source": [
+    "## Import Strategy from pyaglostrategypool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e06b89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
+    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "6cbd40df",
@@ -133,25 +152,6 @@
    "metadata": {},
    "source": [
     "# Strategy Testing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d12741c",
-   "metadata": {},
-   "source": [
-    "## Import Strategy from pyaglostrategypool"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15e06b89",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
-    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
    ]
   },
   {
@@ -32471,7 +32471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -2,6 +2,7 @@
 Module for AlgoBulls connection
 """
 import inspect
+import os
 import pprint
 import re
 import time
@@ -461,7 +462,7 @@ class AlgoBullsConnection:
 
         return _df
 
-    def get_report_statistics(self, strategy_code, initial_funds, report, html_dump, pnl_df):
+    def get_report_statistics(self, strategy_code=None, initial_funds=None, report="full", html_dump=True, pnl_df=None, file_path="None", date_time_format="%Y-%m-%d %H:%M:%S%z"):
         """
             Fetch BT/PT/RT report statistics
 
@@ -471,9 +472,32 @@ class AlgoBullsConnection:
                 html_dump: save it as a html file
                 pnl_df: dataframe containing pnl reports
                 initial_funds: initial funds to before starting the job
+                file_path: file path of the csv or xlsx containing pnl data for statistics
+                date_time_format: datetime format of the column inside the "entry_timestamp" column in the csv or xlxs file
             Returns:
                 Report details
         """
+
+        if os.path.isfile(file_path):
+            # only accept csv or xlxs files
+            _, _ext = os.path.splitext(file_path)
+            if _ext == '.csv':
+                pnl_df = pd.read_csv(file_path)
+            elif _ext == '.xlxs':
+                pnl_df = pd.read_excel(file_path)
+            else:
+                raise Exception(f'ERROR: File with extention {_ext} is not supported.\n Please provide path to files with extention as ".csv" or ".xlxs"')
+
+            # handle the exceptions gracefuly, providing the info why an error was raised
+            if "entry_timestamp" not in pnl_df.columns or "pnl_absolute" not in pnl_df.columns:
+                raise Exception(f"ERROR: Given  {_ext} file does not have the required columns 'entry_timestamp' and 'pnl_absolute'.")
+            try:
+                dt.strptime(pnl_df.iloc[0]["entry_timestamp"], date_time_format)
+            except ValueError:
+                raise ValueError(f"ERROR: Datetime strings inside 'entry_timestamp' column should be of the format {date_time_format}.")
+
+            # cleanup dataframe generated from read files
+            pnl_df[['entry_timestamp']] = pnl_df[['entry_timestamp']].apply(pd.to_datetime, format=date_time_format, errors="coerce")
 
         order_report = None
 
@@ -492,15 +516,21 @@ class AlgoBullsConnection:
         total_funds_series = _returns_df.total_funds
 
         # select report type
-        if report == "metrics":
-            order_report = qs.reports.metrics(total_funds_series)
-        elif report == "full":
-            order_report = qs.reports.full(total_funds_series)
+        try:
+            if report == "metrics":
+                order_report = qs.reports.metrics(total_funds_series)
+            elif report == "full":
+                order_report = qs.reports.full(total_funds_series)
+        except ZeroDivisionError:
+            raise Exception("ERROR: PnL data generated is too less to perform statistical analysis")
 
         # save as html file
         if html_dump:
-            all_strategies = self.get_all_strategies()
-            strategy_name = all_strategies.loc[all_strategies['strategyCode'] == strategy_code]['strategyName'].iloc[0]
+            try:
+                all_strategies = self.get_all_strategies()
+                strategy_name = all_strategies.loc[all_strategies['strategyCode'] == strategy_code]['strategyName'].iloc[0]
+            except Exception as e:
+                strategy_name = 'strategy_results'
             qs.reports.html(total_funds_series, title=strategy_name, output='', download_filename=f'report_{strategy_name}_{time.time():.0f}.html')
 
         return order_report


### PR DESCRIPTION
- Inside the function `get_report_statistics` a new parameter is added `file_path`
- This file path can only take `csv` files or `xlxs` files as input
- The `csv/xlxs` file should include 2 necessary columns `entry_timestamp` and `pnl_absolute`
- Another parameter "date_time_format" is introduced to give the format of all the entries inside the "entry_timestamp" column
- Added Exceptions wherever necessary inside the `get_report_statistics` function
- All exceptions are handled gracefully here
- The Quantstats bug for `ZeroDivision` Error is also handled here
- This PR is closes in PR #65 
