### PR TITLE
Bug: Order history new API is added

### DIFF
--- a/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
+++ b/jupyter/nse_equity/inverse_ema_scalping_crossover.ipynb
@@ -84,6 +84,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6d12741c",
+   "metadata": {},
+   "source": [
+    "## Import Strategy from pyaglostrategypool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e06b89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
+    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "6cbd40df",
@@ -133,25 +152,6 @@
    "metadata": {},
    "source": [
     "# Strategy Testing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d12741c",
-   "metadata": {},
-   "source": [
-    "## Import Strategy from pyaglostrategypool"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15e06b89",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -O inverse_ema_scalping_crossover.py https://raw.githubusercontent.com/algobulls/pyalgostrategypool/master/pyalgostrategypool/inverse_ema_scalping.py\n",
-    "! sed -i '1s/^/from pyalgotrading.strategy import StrategyBase\\n/' inverse_ema_scalping_crossover.py"
    ]
   },
   {
@@ -32471,7 +32471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyalgotrading/algobulls/api.py
+++ b/pyalgotrading/algobulls/api.py
@@ -440,7 +440,7 @@ class AlgoBullsAPI:
 
         return response
 
-    def get_reports(self, strategy_code: str, trading_type: TradingType, report_type: TradingReportType, country: str) -> dict:
+    def get_reports(self, strategy_code: str, trading_type: TradingType, report_type: TradingReportType, country: str, current_page: int) -> dict:
         """
         Fetch report for a strategy
 
@@ -449,14 +449,13 @@ class AlgoBullsAPI:
             trading_type: Value of TradingType Enum
             report_type: Value of TradingReportType Enum
             country: Country of the exchange
-
+            current_page: current page of data being retrieved (for order history)
         Returns:
             Report data
 
         Info: ENDPOINT
-            `GET` v2/user/strategy/pltable          for P&L Table
-            `GET` v2/user/strategy/statstable       for Stats Table
-            `GET` v2/user/strategy/orderhistory     Order History
+            `GET` v4/book/pl/data                       for P&L Table
+            `GET` v5/build/python/user/order/charts     Order History
         """
 
         key = self.__get_key(strategy_code=strategy_code, trading_type=trading_type)
@@ -465,8 +464,8 @@ class AlgoBullsAPI:
             endpoint = f'v4/book/pl/data'
             params = {'pageSize': 0, 'isPythonBuild': "true", 'strategyId': strategy_code, 'isLive': trading_type is TradingType.REALTRADING, 'country': country, 'filters': _filter}
         elif report_type is TradingReportType.ORDER_HISTORY:
-            endpoint = 'v2/user/strategy/orderhistory'
-            params = {'key': key}
+            endpoint = 'v5/build/python/user/order/charts'
+            params = {'strategyId': strategy_code, 'country': "USA", 'currentPage': current_page, 'pageSize': 1000, 'isLive': trading_type is TradingType.REALTRADING}
         else:
             raise NotImplementedError
 

--- a/pyalgotrading/algobulls/connection.py
+++ b/pyalgotrading/algobulls/connection.py
@@ -406,11 +406,13 @@ class AlgoBullsConnection:
             main_data = []
             total_data = 0
             i = 1
+
             while True:
                 response = self.api.get_reports(strategy_code=strategy_code, trading_type=trading_type, report_type=report_type, country=country, current_page=i)
                 _total = response.get("totalTrades")
                 _data = response.get("data")
 
+                # if data is retrieved as a list then update the main data
                 if _data and isinstance(_data, list):
                     main_data.extend(_data)
                     total_data += 1000
@@ -418,23 +420,37 @@ class AlgoBullsConnection:
                 else:
                     break
 
+                # break if total requested data is more than total data
                 if total_data > _total:
                     break
 
         if main_data:
+            # for rendering as dataframe
             if render_as_dataframe:
                 if show_all_rows:
                     pandas_dataframe_all_rows()
+
+                # PNL data
                 _response = pd.DataFrame(response['data'])
+
+                # Order History data
                 if report_type is TradingReportType.ORDER_HISTORY:
+                    # explode the "customer_tradebook_states" column to get separate rows for every state
                     df = _response.explode('customer_tradebook_states').reset_index(drop=True)
                     df = df.join(pd.json_normalize(df.pop('customer_tradebook_states')))
                     _response = df.set_index("orderId").sort_values("timestamp_created")[["timestamp_created", "transaction_type", "state", "instrument", "quantity", "currency", "price"]]
+
+            # for rendering as string or json
             else:
+                # PNL data
                 _response = main_data
+
+                # Order History data
                 if report_type is TradingReportType.ORDER_HISTORY:
                     main_order_string = ""
+
                     for i in range(len(main_data)):
+                        # table for displaying order details
                         order_detail = [
                             ["Order ID", main_data[i]["orderId"]],
                             ["Transaction Type", main_data[i]["transaction_type"]],
@@ -443,9 +459,13 @@ class AlgoBullsConnection:
                             ["Price", str(main_data[i]["currency"]) + str(main_data[i]["price"])]
                         ]
                         main_order_string += tabulate(order_detail, tablefmt="psql") + "\n"
+
+                        # table for displaying order status data
                         main_order_string += tabulate(main_data[i]["customer_tradebook_states"], headers="keys", tablefmt="psql") + "\n"
+
                         main_order_string += '\n' + '======' * 15 + '\n'
                     _response = main_order_string
+
             return _response
         else:
             print('Report not available yet. Please retry in sometime')


### PR DESCRIPTION
- The older version of API has been disabled from the backend
- The order history API now returns list of multiple dictionaries. Once dictionary for every order.
- It also returns the total number of trades, this is to guide us for managing the number of page and total number of rows per page.
- Inside the key `customer_tradebook_states` there are multiple dictionaries of every states of the order. It will the status time and the status.
- There is new feature added to render this order status history as dataframe.
- This PR is closes in PR #65 
