### PR TITLE
added redirects for gen_ai docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,8 @@ plugins:
       redirect_maps:
           'strategies/common_regular_strategy.md': 'strategies/strategy_guides/common_regular_strategy.md'
           'strategies/common_options_strategy.md': 'strategies/strategy_guides/common_options_strategy.md'
+          'gen_ai_guide.md': 'gen_ai/get_open_ai_keys.md'
+
 
 google_analytics:
   - 'UA-147658856-4'


### PR DESCRIPTION
issue of broken links caused by recent updates in our documentation. To ensure that recent links continue to work seamlessly and redirect to the latest content, have added the mkdocs-redirects.