### PR TITLE
Add hyper link for Talib docs

### DIFF
--- a/docs/strategies/strategy_guides/common_strategy_guide.md
+++ b/docs/strategies/strategy_guides/common_strategy_guide.md
@@ -189,7 +189,7 @@ Historical data of the instrument up to a certain point in your strategy is coll
     ema_x = talib.EMA(hist_data['close'], timeperiod=self.timeperiod1)
     ema_y = talib.EMA(hist_data['close'], timeperiod=self.timeperiod2)
     ```
-    As you can see, we have passed the “close” column and a strategy parameter value called “self.timeperiod1” and “self.timeperiod2” to the talib function. Each of the talib functions require unique input values, some require pandas.Series, some require constants like integers and floats and some require both. To understand the working of each talib function, refer here.
+    As you can see, we have passed the “close” column and a strategy parameter value called “self.timeperiod1” and “self.timeperiod2” to the talib function. Each of the talib functions require unique input values, some require pandas.Series, some require constants like integers and floats and some require both. To understand the working of each talib function, refer [here](https://hexdocs.pm/talib/api-reference.html).
 
 - Next, you analyze this data to determine trading signals and calculate indicator values. You can rely on functions from "**talib**" for this, as shown below:
     ```python


### PR DESCRIPTION
Add a hyperlink for the Talib documentation. Please refer to the attached screenshot below.

![image](https://github.com/algobulls/pyalgotrading/assets/122528884/b6e8a5cb-294f-410a-94b9-ba1ff1163007)
